### PR TITLE
[FOUND-2] Implement Hash Strategies in foundation-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # foundation-core
 A centralized, multi-language library of foundational abstractions and utilities, designed for reuse across projects, providing essential components like auditing, data models, and utilities.
+
+# Getting Started With Maven
+
+### Reference Documentation
+
+For further reference, please consider the following sections:
+
+* [Official Apache Maven documentation](https://maven.apache.org/guides/index.html)
+* [Spring Boot Maven Plugin Reference Guide](https://docs.spring.io/spring-boot/3.3.2/maven-plugin)
+* [Create an OCI image](https://docs.spring.io/spring-boot/3.3.2/maven-plugin/build-image.html)
+* [Spring Data JPA](https://docs.spring.io/spring-boot/docs/3.3.2/reference/htmlsingle/index.html#data.sql.jpa-and-spring-data)
+
+### Guides
+
+The following guides illustrate how to use some features concretely:
+
+* [Accessing Data with JPA](https://spring.io/guides/gs/accessing-data-jpa/)
+
+### Maven Parent overrides
+
+Due to Maven's design, elements are inherited from the parent POM to the project POM.
+While most of the inheritance is fine, it also inherits unwanted elements like `<license>`
+and `<developers>` from the parent.
+To prevent this, the project POM contains empty overrides for these elements.
+If you manually switch to a different parent and actually want the inheritance, you need to remove
+those overrides.

--- a/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/HashVerifier.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/HashVerifier.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Verifier for checking if an input string, when hashed, matches a provided hash.
+ * This class is designed to work with any implementation of the HashStrategy interface,
+ * enabling reusable and consistent verification logic across different hash algorithms.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash;
+
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.HashStrategy;
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HashVerifier {
+
+    private final MessageResolver messageResolver;
+
+    @Autowired
+    public HashVerifier(MessageResolver messageResolver) {
+        this.messageResolver = messageResolver;
+    }
+
+    /**
+     * Verifies if the input, when hashed using the provided HashStrategy, matches the provided hash.
+     *
+     * @param input the input to hash and compare
+     * @param hash the expected hash
+     * @param hashStrategy the strategy to use for hashing the input
+     * @return true if the hashed input matches the provided hash, false otherwise
+     * @throws InvalidInputException if the input or hash is null
+     */
+    public boolean verify(String input, String hash, HashStrategy hashStrategy) {
+        if (input == null || hash == null) {
+            throw new InvalidInputException("input.invalid", input, messageResolver);
+        }
+        String generatedHash = hashStrategy.generateHash(input);
+        return generatedHash.equals(hash);
+    }
+}

--- a/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/HashStrategy.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/HashStrategy.java
@@ -16,31 +16,16 @@
  * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
  * See the License for the specific language governing permissions and limitations under the License.
  *
- * Main application class for the Bruno Santos Foundation Library, responsible for initializing the Spring context.
- * This class serves as the entry point for the application.
+ * Interface defining a strategy for generating hashes. Implementations of this interface
+ * can provide different hash algorithms as needed.
  *
  * @author Bruno da Silva Santos <contact@brunosantos.app>
  * @since 0.0.1-alpha
  * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
  */
-package app.brunosantos.foundation.lib;
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+public interface HashStrategy {
 
-/**
- * Main application class for the Bruno Santos Foundation Library.
- */
-@SpringBootApplication(scanBasePackages = "app.brunosantos.core.foundation.lib")
-public class BrunoSantosFoundationLibraryApplication {
-
-  /**
-   * Runs the Spring application with the provided command-line arguments.
-   *
-   * @param args command-line arguments
-   */
-  public static void main(String[] args) {
-    SpringApplication.run(BrunoSantosFoundationLibraryApplication.class, args);
-  }
-
+    String generateHash(String input);
 }

--- a/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Md5HashStrategy.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Md5HashStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Implementation of the HashStrategy interface using the MD5 algorithm.
+ * This class provides a secure mechanism for generating hashes with MD5.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy;
+
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Md5HashStrategy implements HashStrategy {
+
+    private final MessageResolver messageResolver;
+
+    @Autowired
+    public Md5HashStrategy(MessageResolver messageResolver) {
+        this.messageResolver = messageResolver;
+    }
+
+    @Override
+    public String generateHash(String input) {
+        if (input == null) {
+            throw new InvalidInputException("input.notNull", input, messageResolver);
+        } else if (input.isEmpty()) {
+            throw new InvalidInputException("input.notEmpty", input, messageResolver);
+        }
+        return DigestUtils.md5Hex(input);
+    }
+}

--- a/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Sha256HashStrategy.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Sha256HashStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Implementation of the HashStrategy interface using the SHA-256 algorithm.
+ * This class provides a secure mechanism for generating hashes with SHA-256.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy;
+
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Sha256HashStrategy implements HashStrategy {
+
+    private final MessageResolver messageResolver;
+
+    @Autowired
+    public Sha256HashStrategy(MessageResolver messageResolver) {
+        this.messageResolver = messageResolver;
+    }
+
+    @Override
+    public String generateHash(String input) {
+        if (input == null) {
+            throw new InvalidInputException("input.notNull", input, messageResolver);
+        } else if (input.isEmpty()) {
+            throw new InvalidInputException("input.notEmpty", input, messageResolver);
+        }
+        return DigestUtils.sha256Hex(input);
+    }
+}

--- a/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Sha512HashStrategy.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/Sha512HashStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Implementation of the HashStrategy interface using the SHA-512 algorithm.
+ * This class provides a secure mechanism for generating hashes with SHA-512.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy;
+
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Sha512HashStrategy implements HashStrategy {
+
+    private final MessageResolver messageResolver;
+
+    @Autowired
+    public Sha512HashStrategy(MessageResolver messageResolver) {
+        this.messageResolver = messageResolver;
+    }
+
+    @Override
+    public String generateHash(String input) {
+        if (input == null) {
+            throw new InvalidInputException("input.notNull", input, messageResolver);
+        } else if (input.isEmpty()) {
+            throw new InvalidInputException("input.notEmpty", input, messageResolver);
+        }
+        return DigestUtils.sha512Hex(input);
+    }
+}

--- a/src/main/java/app/brunosantos/foundation/lib/commons/messages/MessageResolver.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/messages/MessageResolver.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Interface for resolving message keys to human-readable strings.
+ * Implementations of this interface are responsible for retrieving localized
+ * messages based on provided keys, typically from a resource bundle. This is
+ * essential for error handling, ensuring that exception messages and other
+ * outputs are meaningful and user-friendly.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.messages;
+
+public interface MessageResolver {
+
+    String resolve(String messageKey);
+}

--- a/src/main/java/app/brunosantos/foundation/lib/commons/messages/ResourceBundleMessageResolver.java
+++ b/src/main/java/app/brunosantos/foundation/lib/commons/messages/ResourceBundleMessageResolver.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Implementation of {@link MessageResolver} using a resource bundle.
+ * This class is responsible for resolving message keys to strings using a specified
+ * resource bundle, allowing for localization and consistent messaging across the application.
+ * It is particularly useful in scenarios where internationalization (i18n) is required.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.messages;
+
+import java.util.ResourceBundle;
+
+public class ResourceBundleMessageResolver implements MessageResolver {
+
+    private final ResourceBundle resourceBundle;
+
+    public ResourceBundleMessageResolver(ResourceBundle resourceBundle) {
+        this.resourceBundle = resourceBundle;
+    }
+
+    @Override
+    public String resolve(String messageKey) {
+        return resourceBundle.getString(messageKey);
+    }
+}

--- a/src/main/java/app/brunosantos/foundation/lib/exception/InvalidInputException.java
+++ b/src/main/java/app/brunosantos/foundation/lib/exception/InvalidInputException.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Exception thrown when the input data for generating a hash is invalid.
+ * This could be due to null or empty input, or other issues that prevent
+ * the hash from being generated correctly.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.exception;
+
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import java.text.MessageFormat;
+public class InvalidInputException extends RuntimeException {
+
+    private final String messageKey;
+    private final transient MessageResolver messageResolver;
+
+    /**
+     * Constructor for InvalidInputException.
+     *
+     * @param messageKey      the key used to resolve the error message
+     * @param messageResolver the resolver used to resolve the message
+     */
+    public InvalidInputException(String messageKey, MessageResolver messageResolver) {
+        super(messageResolver.resolve(messageKey));
+        this.messageKey = messageKey;
+        this.messageResolver = messageResolver;
+    }
+
+    /**
+     * Constructor for InvalidInputException with a formatted message.
+     *
+     * @param messageKey      the key used to resolve the error message
+     * @param input           the invalid input that caused the exception
+     * @param messageResolver the resolver used to resolve the message
+     */
+    public InvalidInputException(String messageKey, String input, MessageResolver messageResolver) {
+        super(MessageFormat.format(messageResolver.resolve(messageKey), input));
+        this.messageKey = messageKey;
+        this.messageResolver = messageResolver;
+    }
+
+    /**
+     * Returns the message key associated with this exception.
+     * 
+     * @return the message key
+     */
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    /**
+     * Provides a mechanism to resolve the message using the MessageResolver.
+     * This will return null if the exception is deserialized without a valid messageResolver.
+     * 
+     * @return the resolved message based on the message key, or null if the resolver is unavailable
+     */
+    public String getResolvedMessage() {
+        if (messageResolver != null) {
+            return messageResolver.resolve(messageKey);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,2 @@
+input.notNull=Input cannot be null
+input.notEmpty=Input cannot be empty

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 spring:
   application:
     name: Bruno Santos Foundation Library
+
+  messages:
+    basename: ValidationMessages
+
+  jpa:
+    hibernate:
+      validator:
+        enabled: true

--- a/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Md5HashStrategyUnitTest.java
+++ b/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Md5HashStrategyUnitTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Unit test for Md5HashStrategy to ensure accurate functionality and reliability in all scenarios.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy.unit;
+
+import app.brunosantos.foundation.lib.commons.identifier.hash.HashVerifier;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Md5HashStrategy;
+import app.brunosantos.foundation.lib.config.TestConfig;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.VALID_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.ANOTHER_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.EMPTY_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.NULL_INPUT;
+/**
+ * Unit tests for {@link Md5HashStrategy}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TestConfig.class})
+class Md5HashStrategyUnitTest {
+
+    @Autowired
+    private Md5HashStrategy md5HashStrategy;
+
+    @Autowired
+    private HashVerifier hashVerifier;
+
+    @ParameterizedTest
+    @MethodSource("app.brunosantos.foundation.lib.util.TestDataProvider#provideValidHashInputsForMd5")
+    void testGenerateHashWithVariousValidInputs(String input, String expectedHash) {
+        String actualHash = md5HashStrategy.generateHash(input);
+        assertEquals(expectedHash, actualHash, "The generated hash should match the expected hash.");
+    }
+
+    @Test
+    void testGenerateHashWithNullInput() {
+        Executable executable = () -> md5HashStrategy.generateHash(NULL_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be null", exception.getMessage(), "The exception message should indicate the input cannot be null.");
+    }
+
+    @Test
+    void testGenerateHashWithEmptyInput() {
+        Executable executable = () -> md5HashStrategy.generateHash(EMPTY_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be empty", exception.getMessage(), "The exception message should indicate the input cannot be empty.");
+    }
+
+    @Test
+    void testVerifyWithMatchingInputAndHash() {
+        String hash = md5HashStrategy.generateHash(VALID_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, md5HashStrategy);
+        assertTrue(result, "The verifier should return true for matching input and hash.");
+    }
+
+    @Test
+    void testVerifyWithNonMatchingInputAndHash() {
+        String hash = md5HashStrategy.generateHash(ANOTHER_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, md5HashStrategy);
+        assertFalse(result, "The verifier should return false for non-matching input and hash.");
+    }
+
+}

--- a/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Sha256HashStrategyUnitTest.java
+++ b/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Sha256HashStrategyUnitTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Unit test for Sha256HashStrategy to ensure accurate functionality and reliability in all scenarios.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy.unit;
+
+import app.brunosantos.foundation.lib.commons.identifier.hash.HashVerifier;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Sha256HashStrategy;
+import app.brunosantos.foundation.lib.config.TestConfig;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.VALID_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.ANOTHER_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.EMPTY_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.NULL_INPUT;
+
+/**
+ * Unit tests for {@link Sha256HashStrategy}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TestConfig.class})
+class Sha256HashStrategyUnitTest {
+
+    @Autowired
+    private Sha256HashStrategy sha256HashStrategy;
+
+    @Autowired
+    private HashVerifier hashVerifier;
+
+    @ParameterizedTest
+    @MethodSource("app.brunosantos.foundation.lib.util.TestDataProvider#provideValidHashInputsForSha256")
+    void testGenerateHashWithVariousValidInputs(String input, String expectedHash) {
+        String actualHash = sha256HashStrategy.generateHash(input);
+        assertEquals(expectedHash, actualHash, "The generated hash should match the expected hash.");
+    }
+
+    @Test
+    void testGenerateHashWithNullInput() {
+        Executable executable = () -> sha256HashStrategy.generateHash(NULL_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be null", exception.getMessage(), "The exception message should indicate the input cannot be null.");
+    }
+
+    @Test
+    void testGenerateHashWithEmptyInput() {
+        Executable executable = () -> sha256HashStrategy.generateHash(EMPTY_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be empty", exception.getMessage(), "The exception message should indicate the input cannot be empty.");
+    }
+
+    @Test
+    void testVerifyWithMatchingInputAndHash() {
+        String hash = sha256HashStrategy.generateHash(VALID_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, sha256HashStrategy);
+        assertTrue(result, "The verifier should return true for matching input and hash.");
+    }
+
+    @Test
+    void testVerifyWithNonMatchingInputAndHash() {
+        String hash = sha256HashStrategy.generateHash(ANOTHER_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, sha256HashStrategy);
+        assertFalse(result, "The verifier should return false for non-matching input and hash.");
+    }
+    
+}

--- a/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Sha512HashStrategyUnitTest.java
+++ b/src/test/java/app/brunosantos/foundation/lib/commons/identifier/hash/strategy/unit/Sha512HashStrategyUnitTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Unit test for Sha512HashStrategy to ensure accurate functionality and reliability in all scenarios.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.commons.identifier.hash.strategy.unit;
+
+import app.brunosantos.foundation.lib.commons.identifier.hash.HashVerifier;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Sha512HashStrategy;
+import app.brunosantos.foundation.lib.config.TestConfig;
+import app.brunosantos.foundation.lib.exception.InvalidInputException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.VALID_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.ANOTHER_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.EMPTY_INPUT;
+import static app.brunosantos.foundation.lib.util.TestDataProvider.NULL_INPUT;
+
+/**
+ * Unit tests for {@link Sha512HashStrategy}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {TestConfig.class})
+class Sha512HashStrategyUnitTest {
+
+    @Autowired
+    private Sha512HashStrategy sha512HashStrategy;
+
+    @Autowired
+    private HashVerifier hashVerifier;
+
+    @ParameterizedTest
+    @MethodSource("app.brunosantos.foundation.lib.util.TestDataProvider#provideValidHashInputsForSha512")
+    void testGenerateHashWithVariousValidInputs(String input, String expectedHash) {
+        String actualHash = sha512HashStrategy.generateHash(input);
+        assertEquals(expectedHash, actualHash, "The generated hash should match the expected hash.");
+    }
+
+    @Test
+    void testGenerateHashWithNullInput() {
+        Executable executable = () -> sha512HashStrategy.generateHash(NULL_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be null", exception.getMessage(), "The exception message should indicate the input cannot be null.");
+    }
+
+    @Test
+    void testGenerateHashWithEmptyInput() {
+        Executable executable = () -> sha512HashStrategy.generateHash(EMPTY_INPUT);
+        InvalidInputException exception = assertThrows(InvalidInputException.class, executable);
+
+        assertEquals("Input cannot be empty", exception.getMessage(), "The exception message should indicate the input cannot be empty.");
+    }
+
+    @Test
+    void testVerifyWithMatchingInputAndHash() {
+        String hash = sha512HashStrategy.generateHash(VALID_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, sha512HashStrategy);
+        assertTrue(result, "The verifier should return true for matching input and hash.");
+    }
+
+    @Test
+    void testVerifyWithNonMatchingInputAndHash() {
+        String hash = sha512HashStrategy.generateHash(ANOTHER_INPUT);
+        boolean result = hashVerifier.verify(VALID_INPUT, hash, sha512HashStrategy);
+        assertFalse(result, "The verifier should return false for non-matching input and hash.");
+    }
+
+}

--- a/src/test/java/app/brunosantos/foundation/lib/config/TestConfig.java
+++ b/src/test/java/app/brunosantos/foundation/lib/config/TestConfig.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Configuration class for setting up beans used in testing.
+ * This configuration provides the necessary components for hash strategies
+ * (MD5, SHA-256, SHA-512) and a hash verifier, enabling consistent and isolated
+ * testing of cryptographic operations. The {@link MessageResolver} bean is also
+ * configured to resolve error messages for input validation.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import app.brunosantos.foundation.lib.commons.identifier.hash.HashVerifier;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Md5HashStrategy;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Sha256HashStrategy;
+import app.brunosantos.foundation.lib.commons.identifier.hash.strategy.Sha512HashStrategy;
+import app.brunosantos.foundation.lib.commons.messages.MessageResolver;
+import app.brunosantos.foundation.lib.commons.messages.ResourceBundleMessageResolver;
+
+import java.util.ResourceBundle;
+
+@Configuration
+public class TestConfig {
+    @Bean
+    public MessageResolver messageResolver() {
+        ResourceBundle resourceBundle = ResourceBundle.getBundle("test-messages");
+        return new ResourceBundleMessageResolver(resourceBundle);
+    }
+
+    @Bean
+    public Md5HashStrategy md5HashStrategy(MessageResolver messageResolver) {
+        return new Md5HashStrategy(messageResolver);
+    }
+
+    @Bean
+    public Sha256HashStrategy sha256HashStrategy(MessageResolver messageResolver) {
+        return new Sha256HashStrategy(messageResolver);
+    }
+
+    @Bean
+    public Sha512HashStrategy sha512HashStrategy(MessageResolver messageResolver) {
+        return new Sha512HashStrategy(messageResolver);
+    }
+
+    @Bean
+    public HashVerifier hashVerifier(MessageResolver messageResolver) {
+        return new HashVerifier(messageResolver);
+    }
+}

--- a/src/test/java/app/brunosantos/foundation/lib/util/TestDataProvider.java
+++ b/src/test/java/app/brunosantos/foundation/lib/util/TestDataProvider.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2024 Bruno da Silva Santos
+ *
+ * Licensed under the Creative Commons Attribution-NonCommercial 4.0 International License
+ * (the "License"). You may not use this file except in compliance with the License.
+ * A copy of the License is available at:
+ *
+ * https://creativecommons.org/licenses/by-nc/4.0/
+ *
+ * This license applies to all content, media, and software included in this project.
+ * Attribution is required, and commercial use is prohibited.
+ * For inquiries or permissions beyond the scope of this license, please contact:
+ * <a href="mailto:contact@brunosantos.app">contact@brunosantos.app</a>.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is provided "AS IS", without warranties or conditions of any kind.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Provides common test data for unit tests.
+ *
+ * @author Bruno da Silva Santos <contact@brunosantos.app>
+ * @since 0.0.1-alpha
+ * @see <a href="https://github.com/brunosantoslab/foundation-lib/wiki">Library Documentation</a>
+ */
+package app.brunosantos.foundation.lib.util;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+public class TestDataProvider {
+
+    public static final String VALID_INPUT = "test";
+    public static final String ANOTHER_INPUT = "anotherTest";
+    public static final String NUMERIC_INPUT = "1234567890";
+    public static final String SPECIAL_CHARACTERS_INPUT = "!@#$%^&*()";
+    public static final String EMPTY_INPUT = "";
+    public static final String NULL_INPUT = null;
+    public static final String WHITESPACE_INPUT = "   ";
+    public static final String LONG_INPUT = "a".repeat(1000);
+    public static final String UNICODE_INPUT = "测试输入";
+
+    private TestDataProvider() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static Stream<Arguments> provideValidHashInputsForMd5() {
+        return Stream.of(
+                Arguments.of(VALID_INPUT, DigestUtils.md5Hex(VALID_INPUT)),
+                Arguments.of(WHITESPACE_INPUT, DigestUtils.md5Hex(WHITESPACE_INPUT)),
+                Arguments.of(SPECIAL_CHARACTERS_INPUT, DigestUtils.md5Hex(SPECIAL_CHARACTERS_INPUT)),
+                Arguments.of(LONG_INPUT, DigestUtils.md5Hex(LONG_INPUT)),
+                Arguments.of(UNICODE_INPUT, DigestUtils.md5Hex(UNICODE_INPUT))
+        );
+    }
+
+    public static Stream<Arguments> provideValidHashInputsForSha256() {
+        return Stream.of(
+                Arguments.of(VALID_INPUT, DigestUtils.sha256Hex(VALID_INPUT)),
+                Arguments.of(ANOTHER_INPUT, DigestUtils.sha256Hex(ANOTHER_INPUT)),
+                Arguments.of(NUMERIC_INPUT, DigestUtils.sha256Hex(NUMERIC_INPUT)),
+                Arguments.of(SPECIAL_CHARACTERS_INPUT, DigestUtils.sha256Hex(SPECIAL_CHARACTERS_INPUT))
+        );
+    }
+
+    public static Stream<Arguments> provideValidHashInputsForSha512() {
+        return Stream.of(
+                Arguments.of(VALID_INPUT, DigestUtils.sha512Hex(VALID_INPUT)),
+                Arguments.of(ANOTHER_INPUT, DigestUtils.sha512Hex(ANOTHER_INPUT))
+        );
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+  h2:
+    console:
+      enabled: true

--- a/src/test/resources/test-messages.properties
+++ b/src/test/resources/test-messages.properties
@@ -1,0 +1,2 @@
+input.notNull=Input cannot be null
+input.notEmpty=Input cannot be empty


### PR DESCRIPTION
### Summary:
* This pull request implements three hashing strategies (MD5, SHA-256, SHA-512) for the `foundation-lib` project. These strategies are designed following the `HashStrategy` interface, and the implementation includes robust input validation and comprehensive unit tests.

### Changes:

#### 1. **Hash Strategies Implementation:**
   * **Md5HashStrategy:**
     * Implemented using Apache Commons Codec for hashing.
     * Includes input validation to ensure non-null and non-empty values.
   * **Sha256HashStrategy:**
     * Developed with similar validation and hashing logic as the MD5 strategy.
   * **Sha512HashStrategy:**
     * Added with consistent validation and hashing approach across all strategies.

#### 2. **Integration with Spring:**
   * Integrated `MessageResolver` for dependency injection in each hash strategy.
   * Configured Spring beans in `TestConfig` to manage the lifecycle of these strategies.

#### 3. **Unit Tests:**
   * Created comprehensive unit tests for each hashing strategy:
     * Covered successful hashing scenarios.
     * Included tests for exceptions related to invalid inputs.

### Issue Link:
* Closes #3 

### Testing:
* Verified that each hashing strategy correctly processes inputs and produces the expected output.
* Ensured that exception handling works as intended for invalid inputs.

### Notes:
* The current implementation supports the most commonly used hash functions. Future work may involve adding more hash algorithms or enhancing input validation rules.